### PR TITLE
set up CI with ruff-tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,8 @@
 name: Lint
 
 on:
-  push:
+  push: 
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check .


### PR DESCRIPTION
Set-up CI ruff-tests
---

_The GitHub Repository was missing automated tests on pushing and PullRequests. 
The PDF-Guide only mentioned the tests for PullRequests but thery were also added on push as it is standard practice for projects that aren't overly large.
Automated Ruff-tests are used._

---
### 📁 .github/workflows/
-added `lint.yml`

