### PR TITLE
Roboter dreht sich zur Maus

### DIFF
--- a/src/Sprint2_RoboArena/Roboter.py
+++ b/src/Sprint2_RoboArena/Roboter.py
@@ -10,6 +10,8 @@ class Robot:
         self.height = 50
         self.speed = 2
         self.aabb = [(self.x, self.y), (self.x + self.width, self.y + self.height)]
+        self.angle = 0
+
 
     # updatet die axis aligned bounding box
     def update_aabb(self):
@@ -27,21 +29,35 @@ class Robot:
         self.update_aabb()
 
     def draw(self):
+
+    # Eigene Fläche
+        robot_surface = pygame.Surface((self.width, self.height), pygame.SRCALPHA)
+
         # Körper
         pygame.draw.rect(
-            self.screen,
-            (120, 120, 120),
-            (self.x, self.y, self.width, self.height)
-        )
+            robot_surface,
+        (120, 120, 120),
+        (0, 0, self.width, self.height)
+    )
 
-        # Kopf / Sensor
+        # Kopf
         pygame.draw.circle(
-            self.screen,
-            (0, 255, 0),
-            (self.x + 25, self.y + 15),
-            8
+            robot_surface,
+        (0, 255, 0),
+        (35, 25),
+        8
         )
 
+        # Rotieren
+        rotated_surface = pygame.transform.rotate(robot_surface, self.angle)
+
+        # Mittelpunkt setzen
+        rect = rotated_surface.get_rect(
+            center=(self.x + self.width / 2, self.y + self.height / 2)
+        )
+
+
+        self.screen.blit(rotated_surface, rect.topleft)
 
     # "Zeichnet AAB-Kollisionbox"
     def draw_aabb(self):
@@ -60,15 +76,14 @@ class Robot:
 
     
         # Linie zur Maus,
-        # Zieht eine Linie von Roboter zur Maus(Erstmal auskommentiert nur zum testen Aktivieren.)
-        '''
+    def draw_line_to_mouse(self):
         mouse_x, mouse_y = pygame.mouse.get_pos()
         pygame.draw.line(
             self.screen, 
             (255, 0, 0),
             (self.x + (self.width/2), self.y + (self.height/2)),
             (mouse_x, mouse_y), 2)
-        '''
+
     def get_direction_to_mouse(self):
         mouse_x, mouse_y = pygame.mouse.get_pos()
         #Berechnet Abstand von Mauszeiger zu sich selbst
@@ -81,3 +96,15 @@ class Robot:
             return dx / distance, dy / distance
 
         return 0,0
+    def update_rotation(self):
+        mouse_x, mouse_y = pygame.mouse.get_pos()
+
+        dx = mouse_x - (self.x + self.width / 2)
+        dy = mouse_y - (self.y + self.height / 2)
+
+        target_angle = math.degrees(math.atan2(-dy, dx))
+
+        # Smooth Rotation
+        angle_difference = (target_angle - self.angle + 180) % 360 - 180
+
+        self.angle += angle_difference * 0.1

--- a/src/Sprint2_RoboArena/Roboter.py
+++ b/src/Sprint2_RoboArena/Roboter.py
@@ -97,12 +97,10 @@ class Robot:
 
         return 0,0
     def update_rotation(self):
-        mouse_x, mouse_y = pygame.mouse.get_pos()
+        direction_x, direction_y = self.get_direction_to_mouse()
 
-        dx = mouse_x - (self.x + self.width / 2)
-        dy = mouse_y - (self.y + self.height / 2)
-
-        target_angle = math.degrees(math.atan2(-dy, dx))
+        target_angle = math.degrees(math.atan2(-direction_y, direction_x)
+        )
 
         # Smooth Rotation
         angle_difference = (target_angle - self.angle + 180) % 360 - 180

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -4,7 +4,7 @@ from Arena import Arena  # ← importieren
 from Roboter import Robot
 from Orb import Orb
 
-TEST_MODE = True     # TESTMODE: wenn true, dann ist testmodus an
+TEST_MODE = True    # TESTMODE: wenn true, dann ist testmodus an
 
 SCREEN_WIDTH = 1000
 SCREEN_HEIGHT = 1000
@@ -50,6 +50,7 @@ while True:
 
     keys = pygame.key.get_pressed()
     robot.move(keys)
+    robot.update_rotation()
 
     # Checke für Kollision
     for orb in orb_list[:]:
@@ -69,6 +70,7 @@ while True:
         for orb in orb_list:
             orb.draw_aabb() 
         robot.draw_aabb()
+        robot.draw_line_to_mouse()
 
     pygame.display.update()
     clock.tick(60)


### PR DESCRIPTION
Unser Roboter dreht sich nun zur Maus hin dadurch kann der Spieler direkt sehen wohin der Roboter schaut.
Später wichtig für Angriffe, Dash oder ähnliche Funktionen.

Wenn die Testfunktion auf True ist, sieht man auch eine LInie vom Roboter zur Maus. Kannn auch später für Collisonchecks oder ähnliches verwendet werden.