### PR TITLE
Neue Arena und Tiles

### DIFF
--- a/src/Sprint2_RoboArena/Arena.py
+++ b/src/Sprint2_RoboArena/Arena.py
@@ -1,5 +1,5 @@
 import pygame
-from Arena_Objects import Wall,Speedtile,Healthtile,Surprisetile
+from Arena_Objects import Wall,Speedtile,Healthtile,Surprisetile,CactusTile,SkullTile,BoneTile, LightningTile, Tornado
 from Camera import Camera
 
 class Arena:
@@ -17,26 +17,246 @@ class Arena:
         self.background_surf = pygame.Surface((self.WIDTH,self.HEIGHT))
         self.background_surf.fill((200, 200, 200))
 
+        # Farbige Map-Zonen
+        self.zones = [
+            # Labyrinth oben links
+            (0, 0, 1500, 1050, (180, 120, 220)),
+            (0, 1050, 1050, 450, (180, 120, 220)),
+
+            # Blitzland oben rechts
+            (1500, 0, 1500, 1050, (255, 120, 120)),
+            (1950, 1050, 1050, 450, (255, 120, 120)),
+
+            # Wüste unten links
+            (0, 1500, 1050, 450, (240, 190, 120)),
+            (0, 1950, 1500, 1050, (240, 190, 120)),
+
+            # Rochland unten rechts
+            (1950, 1500, 1050, 450, (170, 170, 170)),
+            (1500, 1950, 1500, 1050, (170, 170, 170)),
+
+            # Healing Spawn Mitte
+            (1050, 1050, 900, 900, (100, 230, 230)),
+        ]
+
         # list of all walls
         #   a wall is (x, y, WIDTH, HEIGHT)
         self.walls = [
-            Wall(self, 1000, 1000, 200, 20),
-            Wall(self, 1000, 1000, 20, 200),
-            Wall(self, 1000, 1000, 200, 20),
-            Wall(self, 1200, 800, 20, 200)
+            # Außenrand
+            Wall(self, 0, 0, 3000, 20),
+            Wall(self, 0, 0, 20, 3000),
+            Wall(self, 0, 2980, 3000, 20),
+            Wall(self, 2980, 0, 20, 3000),
+
+            # Labyrinth-Wände
+            Wall(self, 80, 80, 160, 20),
+            Wall(self, 80, 80, 20, 20),
+            Wall(self, 320, 180, 180, 20),
+            Wall(self, 440, 60, 20, 140),
+            Wall(self, 440, 60, 180, 20),
+            Wall(self, 780, 60, 420, 20),
+            Wall(self, 780, 60, 20, 180),
+
+            Wall(self, 920, 190, 20, 360),
+
+            Wall(self, 920, 390, 360, 20),
+            Wall(self, 1340, 60, 120, 20),
+            Wall(self, 1400, 60, 20, 360),
+
+            Wall(self, 120, 430, 240, 20),
+            Wall(self, 120, 430, 20, 180),
+
+            Wall(self, 210, 530, 20, 110),
+            Wall(self, 440, 320, 240, 20),
+            Wall(self, 440, 320, 20, 240),
+            Wall(self, 620, 500, 20, 120),
+            Wall(self, 620, 620, 120, 20),
+
+            # Rechte Mitte
+            Wall(self, 1120, 500, 240, 20),
+            Wall(self, 1120, 500, 20, 250),
+
+            Wall(self, 1260, 500, 20, 250),
+
+            Wall(self, 1020, 500, 20, 180),
+            Wall(self, 1320, 500, 120, 20),
+            Wall(self, 1380, 690, 80, 20),
+            Wall(self, 1440, 590, 20, 100),
+            Wall(self, 1340, 590, 40, 40),
+            Wall(self, 1000, 300, 170, 20),
+
+            Wall(self, 1150, 180, 20, 120),
+
+            Wall(self, 800, 300, 60, 100),
+            Wall(self, 760, 450, 20, 100),
+            Wall(self, 210, 260, 100, 100),
+
+            Wall(self, 380, 200, 20, 80),
+
+            Wall(self, 650, 120, 20, 130),
+            Wall(self, 620, 700, 360, 20),
+            Wall(self, 620, 700, 20, 120),
+
+            Wall(self, 60, 750, 240, 20),
+            Wall(self, 60, 750, 20, 180),
+            Wall(self, 140, 870, 240, 20),
+
+            Wall(self, 380, 690, 120, 20),
+            Wall(self, 380, 690, 20, 120),
+
+            Wall(self, 500, 690, 20, 120),
+
+            Wall(self, 920, 810, 320, 20),
+            Wall(self, 920, 810, 20, 180),
+            Wall(self, 1120, 810, 20, 180),
+
+            Wall(self, 1280, 890, 120, 20),
+            Wall(self, 1400, 770, 20, 180),
+
+            Wall(self, 1280, 890, 20, 60),
+            Wall(self, 155, 945, 240, 20),
+            Wall(self, 155, 945, 20, 300),
+
+            Wall(self, 380, 1050, 360, 20),
+            Wall(self, 380, 1050, 20, 240),
+            Wall(self, 660, 930, 20, 260),
+
+            Wall(self, 1000, 1050, 20, 180),
+            Wall(self, 80, 1400, 180, 20),
+            Wall(self, 80, 1280, 20, 120),
+
+            Wall(self, 260, 1400, 20, 60),
+            Wall(self, 580, 1180, 20, 120),
+            Wall(self, 580, 1250, 280, 20),
+
+            Wall(self, 860, 1250, 20, 120),
+
+            Wall(self, 380, 1360, 300, 20),
+            Wall(self, 750, 800, 80, 80),
+            Wall(self, 800, 940, 20, 60),
+            Wall(self, 500 , 900 , 20 , 150),
+            Wall(self, 800, 1100, 250, 20),
+            Wall(self, 250, 1100, 20, 300),
+
+
+            # Wüste Wände
+
+            Wall(self, 300, 2000, 100,100),
+
+            Wall(self, 200, 2500,50,90),
+            Wall(self, 900, 1700, 90,90),
+            Wall(self, 700, 2500,50,100),
+            Wall(self, 750, 2450,50,150),
+
+
+
+
+
+
         ]
+        #Schabrettmusster für das Quadrat
+        ROCK_SIZE = 100
+        SPACING = 200
+
+        # Quadrat unten rechts
+        for row in range(5):
+            for col in range(5):
+                if (row + col) % 2 == 0:
+                    x = 2050 + col * SPACING
+                    y = 2050 + row * SPACING
+
+                    self.walls.append(
+                        Wall(self, x, y, ROCK_SIZE, ROCK_SIZE)
+                    )
+
+
+        # Rechteck oben rechts
+        for row in range(2):
+            for col in range(5):
+                if (row + col) % 2 == 0:
+                    x = 2050 + col * SPACING
+                    y = 1550 + row * SPACING
+
+                    self.walls.append(
+                        Wall(self, x, y, ROCK_SIZE, ROCK_SIZE)
+                    )
+
+
+        # Rechteck links unten
+        for row in range(5):
+            for col in range(2):
+                if (row + col) % 2 == 0:
+                    x = 1550 + col * SPACING
+                    y = 2050 + row * SPACING
+
+                    self.walls.append(
+                        Wall(self, x, y, ROCK_SIZE, ROCK_SIZE)
+                    )
 
         # list of all tiles
         #   a tile is (x,y)
         self.tiles = [
-            Speedtile(self, 1500, 1500),
 
-            Healthtile(self, 1200,1200), 
+            #Tile Labyrinth
             Healthtile(self, 500,500),
+            Healthtile(self, 200, 100),
+            Healthtile(self, 1200, 430),
 
-            Surprisetile(self, 1200, 1500), 
-            Surprisetile(self, 1750,250)
+            Speedtile(self, 200, 1000),
+            Speedtile(self,1000,100),
+            Speedtile(self, 900, 1200),
+
+            Surprisetile(self, 500,500),
+            Surprisetile(self, 800,900),
+
+            # Wüsten-Tiles(Nur optik)
+            CactusTile(self, 250, 1800),
+            CactusTile(self, 500, 2200),
+            CactusTile(self, 800, 2600),
+
+            SkullTile(self, 700, 1900),
+            SkullTile(self, 1000, 2400),
+
+            BoneTile(self, 350, 2500),
+            BoneTile(self, 1200, 2100),
+            BoneTile(self, 900, 2800),
+
+            #Tiles wüste
+            Speedtile(self, 250, 1700),
+            Speedtile(self, 700, 2100),
+            Speedtile(self, 1200, 2600),
+
+            Healthtile(self, 500, 1900),
+            Healthtile(self, 950, 2300),
+            Healthtile(self, 300, 2750),
+
+            Surprisetile(self, 800, 1800),
+            Surprisetile(self, 1100, 2000),
+            Surprisetile(self, 600, 2500),
+
+
+
+
         ]
+
+        #Lighting Tiles Anzahl
+        self.lightning_tiles = [
+            LightningTile(self),
+            LightningTile(self),
+            LightningTile(self),
+            LightningTile(self)
+
+       ]
+        #Tornado Tiles
+        self.tornado = Tornado(self)
+    #Update Methode für Tornado 
+    def update_tornado(self, robot, health):
+        self.tornado.update(robot, health)
+
+    #Update Mehtode für Lightning
+    def update_lightning_tiles(self, robot, health):
+        for lightning in self.lightning_tiles:
+            lightning.update(robot, health)
 
 
     # checks if a rectangle is visible on the screen
@@ -54,24 +274,41 @@ class Arena:
     # draws all walls which are in screen
     def draw_walls(self):
         for wall in self.walls:
-            if(self.is_rect_onscreen(wall)):
-                wall.draw()
+            wall.draw()
 
     # draws all tiles which are in screen
     def draw_tiles(self):
         for tile in self.tiles:
-            if(self.is_rect_onscreen(tile)):
-                tile.draw()
+            tile.draw()
+
+    # Zeichen die Zonen
+    def draw_zones(self):
+        for x, y, width, height, color in self.zones:
+            screen_x = x - self.camera.x + self.screen.get_width() / 2
+            screen_y = y - self.camera.y + self.screen.get_height() / 2
+
+            pygame.draw.rect(
+                self.screen,
+                color,
+                (screen_x, screen_y, width, height)
+            )
 
     # Zeichne alle Arena-Objekte und Hintergründe
     def draw(self, robot):
 
         # Zeichne Hintergrund
-        self.screen.blit(self.background_surf, (0, 0))
-
         self.camera.update(robot)
+
+        self.screen.fill((0, 0, 0))
+
+        self.draw_zones()
         self.draw_walls()
         self.draw_tiles()
+        self.tornado.draw()
+
+        #Blitze zeichen
+        for lightning in self.lightning_tiles:
+            lightning.draw()
 
     # Zeichne AABBs
     def draw_aabb(self):

--- a/src/Sprint2_RoboArena/Arena_Objects.py
+++ b/src/Sprint2_RoboArena/Arena_Objects.py
@@ -117,3 +117,272 @@ class Surprisetile:
 
     def draw_aabb(self):
          draw_aabb(self) # globale Methode
+
+class CactusTile:
+    COLOR = (0, 150, 0) #grün
+    width = 40
+    height = 40
+
+    def __init__(self, arena, x, y):
+        self.arena = arena
+        self.screen = arena.screen
+        self.camera = arena.camera
+
+        self.x = x
+        self.y = y
+
+        self.aabb = AABB(
+            x, y,
+            x + self.width,
+            y + self.height
+        )
+
+        self.surface = pygame.Surface((self.width, self.height))
+        self.surface.fill(self.COLOR)
+
+    def draw(self):
+        draw(self)
+
+    def draw_aabb(self):
+        draw_aabb(self)
+
+
+class SkullTile:
+    COLOR = (70, 70, 70) # Dunkel grau
+    width = 30
+    height = 30
+
+    def __init__(self, arena, x, y):
+        self.arena = arena
+        self.screen = arena.screen
+        self.camera = arena.camera
+
+        self.x = x
+        self.y = y
+
+        self.aabb = AABB(
+            x, y,
+            x + self.width,
+            y + self.height
+        )
+
+        self.surface = pygame.Surface((self.width, self.height))
+        self.surface.fill(self.COLOR)
+
+    def draw(self):
+        draw(self)
+
+    def draw_aabb(self):
+        draw_aabb(self)
+
+
+class BoneTile:
+    COLOR = (245, 245, 220) #weiß
+    width = 35
+    height = 15
+
+    def __init__(self, arena, x, y):
+        self.arena = arena
+        self.screen = arena.screen
+        self.camera = arena.camera
+
+        self.x = x
+        self.y = y
+
+        self.aabb = AABB(
+            x, y,
+            x + self.width,
+            y + self.height
+        )
+
+        self.surface = pygame.Surface((self.width, self.height))
+        self.surface.fill(self.COLOR)
+
+    def draw(self):
+        draw(self)
+
+    def draw_aabb(self):
+        draw_aabb(self)
+
+class LightningTile:
+    COLOR = (250, 250, 250)   # hellblau
+    width = 80
+    height = 80
+
+    LIFETIME = 2000         # bleibt 2 Sekunden
+    DAMAGE = 5              # Schaden pro Treffer
+    DAMAGE_COOLDOWN = 500   # Schaden nur alle 0.5 Sekunden
+
+    def __init__(self, arena):
+        self.arena = arena
+        self.screen = arena.screen
+        self.camera = arena.camera
+
+        self.last_damage_time = 0
+        self.spawn_random()
+
+    def spawn_random(self):
+        import random
+
+        # Blitz-Arena besteht aus 2 Rechtecken:
+        # 1. oben rechts
+        # 2. rechts neben der Healzone
+
+        spawn_areas = [
+            (1500, 0, 1500, 1050),      # oben rechts
+            (1950, 1050, 1050, 450),    # rechts neben Healzone
+        ]
+
+        area = random.choice(spawn_areas)
+
+        area_x, area_y, area_width, area_height = area
+
+        self.x = random.randint(area_x, area_x + area_width - self.width)
+        self.y = random.randint(area_y, area_y + area_height - self.height)
+
+        self.spawn_time = pygame.time.get_ticks()
+
+        self.aabb = AABB(
+            self.x,
+            self.y,
+            self.x + self.width,
+            self.y + self.height
+        )
+
+        self.surface = pygame.Surface((self.width, self.height))
+        self.surface.fill(self.COLOR)
+
+    def update(self, robot, health):
+        current_time = pygame.time.get_ticks()
+
+        self.aabb.update(
+            self.x,
+            self.y,
+            self.x + self.width,
+            self.y + self.height
+        )
+
+        if self.aabb.check_collision(robot.aabb):
+            if current_time - self.last_damage_time >= self.DAMAGE_COOLDOWN:
+                health.take_damage(self.DAMAGE)
+                self.last_damage_time = current_time
+
+        if current_time - self.spawn_time >= self.LIFETIME:
+            self.spawn_random()
+
+    def draw(self):
+        x_screen, y_screen = self.camera.global_to_screen(self)
+        self.screen.blit(self.surface, (x_screen, y_screen))
+
+    def draw_aabb(self):
+        draw_aabb(self)
+
+class Tornado:
+    COLOR = (80, 80, 80)
+
+    width = 70
+    height = 70
+
+    SPEED_X = 4
+    SPEED_Y = 3
+
+    DAMAGE = 8
+    DAMAGE_COOLDOWN = 600
+
+    def __init__(self, arena):
+        self.arena = arena
+        self.screen = arena.screen
+        self.camera = arena.camera
+
+        # Startposition in der Blitz-Zone
+        self.x = 2000
+        self.y = 400
+
+        self.dx = self.SPEED_X
+        self.dy = self.SPEED_Y
+
+        self.last_damage_time = 0
+
+        self.aabb = AABB(
+            self.x,
+            self.y,
+            self.x + self.width,
+            self.y + self.height
+        )
+
+        self.surface = pygame.Surface((self.width, self.height))
+        self.surface.fill(self.COLOR)
+
+    def update(self, robot, health):
+        current_time = pygame.time.get_ticks()
+
+        old_x = self.x
+        old_y = self.y
+
+        self.x += self.dx
+        self.y += self.dy
+
+        # Blitz-Arena-Grenzen
+        min_x = 1500
+        max_x = 3000 - self.width
+        min_y = 0
+        max_y = 1500 - self.height
+
+        # Healzone
+        heal_x = 1050
+        heal_y = 1050
+        heal_w = 900
+        heal_h = 900
+
+        # Rand-Abprall
+        if self.x <= min_x or self.x >= max_x:
+            self.dx *= -1
+            self.x = old_x
+
+        if self.y <= min_y or self.y >= max_y:
+            self.dy *= -1
+            self.y = old_y
+
+        # Aktuelle AABB updaten
+        self.aabb.update(
+            self.x,
+            self.y,
+            self.x + self.width,
+            self.y + self.height
+        )
+
+        # Healzone-AABB temporär bauen
+        heal_aabb = AABB(
+            heal_x,
+            heal_y,
+            heal_x + heal_w,
+            heal_y + heal_h
+        )
+
+        # Wenn Tornado Healzone berührt: zurücksetzen und Richtung ändern
+        if self.aabb.check_collision(heal_aabb):
+            self.x = old_x
+            self.y = old_y
+
+            self.dx *= -1
+            self.dy *= -1
+
+            self.aabb.update(
+                self.x,
+                self.y,
+                self.x + self.width,
+                self.y + self.height
+            )
+
+        # Schaden
+        if self.aabb.check_collision(robot.aabb):
+            if current_time - self.last_damage_time >= self.DAMAGE_COOLDOWN:
+                health.take_damage(self.DAMAGE)
+                self.last_damage_time = current_time
+
+    def draw(self):
+        x_screen, y_screen = self.camera.global_to_screen(self)
+        self.screen.blit(self.surface, (x_screen, y_screen))
+
+    def draw_aabb(self):
+        draw_aabb(self)

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -9,8 +9,8 @@ from Enemy import Enemy
 from Level import Level
 TEST_MODE = False    # TESTMODE: wenn true, dann ist testmodus an
 
-SCREEN_WIDTH = 1000
-SCREEN_HEIGHT = 1000
+SCREEN_WIDTH = 2000
+SCREEN_HEIGHT = 2000
 
 
 pygame.init()
@@ -52,6 +52,8 @@ while True:
     keys = pygame.key.get_pressed()
     robot.move(keys)
     robot.update_rotation()
+    arena.update_lightning_tiles(robot, health)
+    arena.update_tornado(robot, health)
 
     # Checke für Kollision von Roboter und Orb
     for orb in orb_list[:]:


### PR DESCRIPTION
Map wurde neu gestaltet, wie im Discord besprochen.

- Das Labyrinth wurde überarbeitet aber etwas anders aufgebaut.
- Für die Rock-Area wurde eine Schachbrett-Logik verwendet.
- In der Wüste wurden neue optische Tiles hinzugefügt Kakteen, Schädel und Knochen.
- In der Blitz-Area wurden zwei neue Gefahren ergänzt:
  - Blitze spawnen zufällig innerhalb der Blitz-Area, bleiben kurz aktiv und verursachen Schaden bei Kontakt.
  - Der Tornado bewegt sich dauerhaft wie ein Bildschirmschoner durch die Blitz-Area, prallt an den Rändern ab und verursacht ebenfalls Schaden bei Kontakt.