### PR TITLE
Feature/arena Add Logic for Walls, Speedtile and Healthtile

### DIFF
--- a/src/Sprint2_RoboArena/Arena_Objects.py
+++ b/src/Sprint2_RoboArena/Arena_Objects.py
@@ -62,9 +62,7 @@ class Wall:
 
   
 class Speedtile:
-    COLOR = (255, 255, 0)
-
-    COLOR = (255, 255, 255)
+    COLOR = (255, 255, 0)     # gelb
     width = 20
     height = 20
      
@@ -94,8 +92,10 @@ class Speedtile:
    
   
   
-class Healthtile(Tile):
-    COLOR = (255, 105, 180)
+class Healthtile:
+    COLOR = (255, 105, 180)  # pink
+    width = 20
+    height = 20
 
     def __init__(self, arena, x, y):
         self.arena = arena
@@ -150,47 +150,9 @@ class Surprisetile:
         
         
 
+
+
 class CactusTile:
-    COLOR = (0, 150, 0) #grün
-    width = 40
-    height = 40
-    
-    def __init__(self, arena, x, y):
-
-        self.arena = arena
-        self.screen = arena.screen
-        self.camera = arena.camera
-
-        self.x = x
-        self.y = y
-
-        self.aabb = AABB(
-            x,
-            y,
-            x + self.width,
-            y + self.height
-        )
-
-        self.surface = pygame.Surface(
-            (self.width, self.height)
-        )
-
-        self.surface.fill(self.COLOR)
-
-    def apply_to(self, robot):
-         pass #TODO: implement an effect
-
-    def draw(self):
-        draw(self)
-
-    def draw_aabb(self):
-        draw_aabb(self)
-
-
-
-
-
-class CactusTile(Tile):
     COLOR = (0, 150, 0)
     width = 40
     height = 40
@@ -286,6 +248,8 @@ class BoneTile():
 
     def draw_aabb(self):
         draw_aabb(self)
+
+
 
 class LightningTile:
     WARNING_COLOR = (255, 255, 0)   # gelbes Warn-Dreieck

--- a/src/Sprint2_RoboArena/Arena_Objects.py
+++ b/src/Sprint2_RoboArena/Arena_Objects.py
@@ -2,6 +2,22 @@ import pygame
 from Collision import AABB
 from Status_Effects import Speed_Buff, Healthgen_Buff
 
+
+# RICHTLINIEN für Klassen:
+#
+#                           Variablen:  arena
+#                                       screen
+#                                       camera
+#                                       x
+#                                       y
+#                                       aabb
+#                           Methoden:   draw()
+#                                       draw_aabb()
+#                                       apply_to(robot)            <- GILT NUR FÜR EFFEKT_TILES
+
+
+
+
 # zeichnet die gegebene Instanz
 def draw(rect):
         rect.aabb.update(rect.x, rect.y,
@@ -94,6 +110,7 @@ class Healthtile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    # adds the effect to the robot
     def apply_to(self, robot):
          status_effect = Healthgen_Buff()
          robot.add_status_effect(status_effect)
@@ -121,6 +138,7 @@ class Surprisetile:
         
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
+
 
     def apply_to(self, robot):
          pass #TODO: implement an effect
@@ -153,6 +171,9 @@ class CactusTile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
+
     def draw(self):
         draw(self)
 
@@ -182,6 +203,9 @@ class SkullTile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
+
     def draw(self):
         draw(self)
 
@@ -210,6 +234,9 @@ class BoneTile:
 
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
+
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
 
     def draw(self):
         draw(self)
@@ -282,6 +309,9 @@ class LightningTile:
 
         if current_time - self.spawn_time >= self.LIFETIME:
             self.spawn_random()
+
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
 
     def draw(self):
         x_screen, y_screen = self.camera.global_to_screen(self)
@@ -392,6 +422,9 @@ class Tornado:
             if current_time - self.last_damage_time >= self.DAMAGE_COOLDOWN:
                 health.take_damage(self.DAMAGE)
                 self.last_damage_time = current_time
+
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
 
     def draw(self):
         x_screen, y_screen = self.camera.global_to_screen(self)

--- a/src/Sprint2_RoboArena/Arena_Objects.py
+++ b/src/Sprint2_RoboArena/Arena_Objects.py
@@ -1,5 +1,6 @@
 import pygame
 from Collision import AABB
+from Status_Effects import Speed_Buff, Healthgen_Buff
 
 # zeichnet die gegebene Instanz
 def draw(rect):
@@ -35,7 +36,7 @@ class Wall:
 
           self.surface = pygame.Surface((width, height))
           self.surface.fill(self.COLOR)
-          
+             
 
     def draw(self):
         draw(self) # globale Methode
@@ -62,6 +63,12 @@ class Speedtile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    # applies the unique effect to the given robot
+    def apply_to(self, robot):
+         status_effect = Speed_Buff()
+         robot.add_status_effect(status_effect)
+         
+
     def draw(self):
         draw(self) # globale Methode
     
@@ -87,6 +94,10 @@ class Healthtile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    def apply_to(self, robot):
+         status_effect = Healthgen_Buff()
+         robot.add_status_effect(status_effect)
+
     def draw(self):
         draw(self) # globale methode
 
@@ -111,6 +122,8 @@ class Surprisetile:
         self.surface = pygame.Surface((self.width, self.height))
         self.surface.fill(self.COLOR)
 
+    def apply_to(self, robot):
+         pass #TODO: implement an effect
 
     def draw(self):
         draw(self) # globale Methode

--- a/src/Sprint2_RoboArena/Roboter.py
+++ b/src/Sprint2_RoboArena/Roboter.py
@@ -4,15 +4,20 @@ from Collision import AABB
 
 
 class Robot:
-    def __init__(self, arena, x, y):
+    def __init__(self, arena, health, stamina, level, x, y):
         self.arena  = arena
         self.camera = arena.camera
         self.screen = arena.screen
+        self.health = health
+        self.stamina = stamina
+        self.level = level
+        self.status_effects = []
         self.x = x
         self.y = y
         self.width = 50
         self.height = 50
-        self.speed = 2
+        self.speed_base = 2
+        self.speed_current = 2
         self.aabb = AABB(self.x,
                          self.y,
                          self.x + self.width,
@@ -36,32 +41,64 @@ class Robot:
         False   # Falls durchläuft, dann kollidiert nicht mit einer Wand
 
 
+
     def move(self, keys):
 
         if keys[pygame.K_w] or keys[pygame.K_UP]:
-            self.y -= self.speed
+            self.y -= self.speed_current
             self.update_aabb()
             if(self.collides_with_wall()):
-                self.y += self.speed
+                self.y += self.speed_current
                 self.update_aabb()
         if keys[pygame.K_s] or keys[pygame.K_DOWN]:
-            self.y += self.speed
+            self.y += self.speed_current
             self.update_aabb()
             if(self.collides_with_wall()):
-                self.y -= self.speed
+                self.y -= self.speed_current
                 self.update_aabb()
         if keys[pygame.K_a] or keys[pygame.K_LEFT]:
-            self.x -= self.speed
+            self.x -= self.speed_current
             self.update_aabb()
             if(self.collides_with_wall()):
-                self.x += self.speed
+                self.x += self.speed_current
                 self.update_aabb()
         if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
-            self.x += self.speed
+            self.x += self.speed_current
             self.update_aabb()
             if(self.collides_with_wall()):
-                self.x -= self.speed
+                self.x -= self.speed_current
                 self.update_aabb()
+
+
+    def add_status_effect(self, effect):
+
+        print(self.status_effects)
+
+        # check if effect already effective
+        for status_effect in self.status_effects:
+            if(isinstance(status_effect, type(effect))):
+                status_effect.renew()
+                return                           # return if effect already active
+        
+        # if not already effective add to status_effects
+        self.status_effects.append(effect)
+
+
+    # updates the status effects list
+    # checks for effect_tiles
+    # applies effects and removes status_effects with ttl==0
+    def update_status_effects(self):
+
+        # check for effect tiles and apply if colliding
+        for tile in self.arena.tiles:
+            if(self.aabb.check_collision(tile.aabb)):
+                tile.apply_to(self)
+
+        # update the status_list
+        for status_effect in self.status_effects:
+            status_effect.apply_to(self)
+            if (status_effect.ttl_current < 0):
+                self.status_effects.remove(status_effect)
 
 
 
@@ -147,3 +184,4 @@ class Robot:
         angle_difference = (target_angle - self.angle + 180) % 360 - 180
 
         self.angle += angle_difference * 0.1
+

--- a/src/Sprint2_RoboArena/Roboter.py
+++ b/src/Sprint2_RoboArena/Roboter.py
@@ -28,16 +28,41 @@ class Robot:
                           self.x + self.width,
                           self.y + self.height)
 
+    # überprüft ob Überschneidung mit einer Wand
+    def collides_with_wall(self):
+        for wall in self.arena.walls:
+            if(self.aabb.check_collision(wall.aabb)):
+                return True
+        False   # Falls durchläuft, dann kollidiert nicht mit einer Wand
+
+
     def move(self, keys):
+
         if keys[pygame.K_w] or keys[pygame.K_UP]:
             self.y -= self.speed
+            self.update_aabb()
+            if(self.collides_with_wall()):
+                self.y += self.speed
+                self.update_aabb()
         if keys[pygame.K_s] or keys[pygame.K_DOWN]:
             self.y += self.speed
+            self.update_aabb()
+            if(self.collides_with_wall()):
+                self.y -= self.speed
+                self.update_aabb()
         if keys[pygame.K_a] or keys[pygame.K_LEFT]:
             self.x -= self.speed
+            self.update_aabb()
+            if(self.collides_with_wall()):
+                self.x += self.speed
+                self.update_aabb()
         if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
             self.x += self.speed
-        self.update_aabb()
+            self.update_aabb()
+            if(self.collides_with_wall()):
+                self.x -= self.speed
+                self.update_aabb()
+
 
 
 

--- a/src/Sprint2_RoboArena/Status_Effects.py
+++ b/src/Sprint2_RoboArena/Status_Effects.py
@@ -1,4 +1,3 @@
-import pygame
 
 
 

--- a/src/Sprint2_RoboArena/Status_Effects.py
+++ b/src/Sprint2_RoboArena/Status_Effects.py
@@ -1,0 +1,87 @@
+import pygame
+
+
+
+# FORDERUNGEN:
+#
+#       Variablen:  ttl_current
+#
+#       Methoden:   renew(self)
+#                   apply_to(self, robot)
+
+
+
+SECOND = 60   # because 60FPS at the Moment
+
+# 01 Speed Buff
+class Speed_Buff:
+
+    def __init__(self):
+        self.ttl_max = 3 * SECOND
+        self.ttl_current = self.ttl_max
+        self.in_use = False        
+        self.speed_factor = 1.5
+        self.speed_buff = 0   # initiation in apply_to()
+
+    # renews the TTL
+    def renew(self):
+        self.ttl_current = self.ttl_max
+
+    # applies the speed buff
+    def apply_to(self, robot):
+
+        # Initial Application of the Buff
+        if(not self.in_use):
+            # compute buff
+            self.speed_buff = robot.speed_base * self.speed_factor
+
+            # apply buff on Initiation
+            if(self.ttl_current > 0):
+                robot.speed_current += self.speed_buff
+                self.in_use = True 
+                return
+            else:
+                return
+            
+        # Revert Buff on TTL=0
+        if(self.ttl_current <= 0):
+            robot.speed_current -= self.speed_buff
+
+        # Tick down Time-to-Live
+        self.ttl_current -= 1
+            
+
+
+class Healthgen_Buff:
+
+    def __init__(self):
+        self.ttl_max = 1 * SECOND
+        self.ttl_current = self.ttl_max
+        self.heal_amount = 0.7                   
+        self.tick_rate = int(0.25 * SECOND)
+        
+
+    def renew(self):
+        time_to_next_tick = self.ttl_current % self.tick_rate  # prevent overclocking (so heal doesnt get triggered permanantly on tile)
+        self.ttl_current = self.ttl_max + time_to_next_tick
+
+    def apply_to(self, robot):
+        current_health = robot.health.current_health
+        max_health = robot.health.max_health
+
+        # if not full HP and is on tick
+        if(current_health < max_health and self.ttl_current % self.tick_rate == 0):
+            # prevent overhealing
+            if(current_health+self.heal_amount > max_health):
+                robot.health.current_health = robot.health.max_health
+            else:
+                robot.health.current_health += self.heal_amount
+
+        # update TTL
+        self.ttl_current -= 1
+
+        
+            
+
+        
+

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -18,9 +18,16 @@ screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
 pygame.display.set_caption("RoboArena")
 clock = pygame.time.Clock()
 
+# Lebens-System:
+health = HealthSystem_Player(screen, max_health=100, bar_x=10, bar_y=10, bar_width=400, bar_height=25)
+# Stamina-System:
+stamina = StaminaSystem_Player(screen, max_stamina=100, bar_x=10, bar_y=40, bar_width=400, bar_height=25)
+# Level-system
+level = Level(screen)
+
 # Create arena object
 arena = Arena(screen)
-robot = Robot(arena, arena.WIDTH/2, arena.HEIGHT/2)   # spawne in der Mitte der Arena
+robot = Robot(arena, health, stamina, level, arena.WIDTH/2, arena.HEIGHT/2)   # spawne in der Mitte der Arena
 orb_list = [Orb(arena,0,0), Orb(arena,0,0)]
 enemy_list = [Enemy(arena,0,0), Enemy(arena,0,0)]
 
@@ -32,17 +39,6 @@ for enemy in enemy_list:
 
 
 
-
-
-# Lebens-System:
-health = HealthSystem_Player(screen, max_health=100, bar_x=10, bar_y=10, bar_width=400, bar_height=25)
-
-# Stamina-System:
-stamina = StaminaSystem_Player(screen, max_stamina=100, bar_x=10, bar_y=40, bar_width=400, bar_height=25)
-
-# Level-system
-level = Level(screen)
-
 while True:
     for event in pygame.event.get():
         if event.type == pygame.QUIT:
@@ -53,11 +49,16 @@ while True:
     robot.move(keys)
     robot.update_rotation()
 
+    robot.update_status_effects()
+
+
     # Checke für Kollision von Roboter und Orb
     for orb in orb_list[:]:
         if robot.aabb.check_collision(orb.aabb):
             level.collect_orb()
             orb.randomize_position()
+
+
 
     # Zeichne Objekte auf den Screen
     screen.fill((0, 0, 0))  # clear previous frame


### PR DESCRIPTION
> Um die Dynamik der Arena zu verbessern, wurde Logik für Wände, Speedtiles und Healthtiles eingeführt.
> Wände sind nun nichtmehr durchlaufbar für den Spieler.
> Die Speedtiles geben einen Speedbonus basierend auf dem Basespeed.
> Healthtiles geben fixed Leben über Zeit.

**Neue Files:**
- Status_Effects.py      <- Enthält Status-Effekt-Klassen

**Neue Methoden**
- `apply_to(robot)`                                          <- _Arena_Objects.py_:   Fügt Status Effekt Objekt dem Roboter hinzu
- `add_status_effect()`, update_status_effect()  <- _Roboter.py_:  fügt status effekt zu roboter,erkennt und updatet effekt-tiles
- `renew()`, `apply_to(robot)`                               <- _Status_Effects.py_: erneuert Effekt, benutzt spezifischen Effekt auf Roboter


**Schlusswort:**
Resolves #33
_Alles wurde lokal getestet und scheint wie gewollt zu funktionieren.
Es ist aufzupassen, dass die Wändeüberprüfung naiv funktioniert, soll bedeuten, wenn der Roboter schnell genug ist, dass er in einem frame von der einen seite der wand zur anderen kommt, dann kann er die Wand überspringen. Dies sollte bisher unmöglich zu erreichen sein, sollte aber doch im Hinterkopf behalten werden._