### PR TITLE
Level wurden ueberarbeitet

### DIFF
--- a/src/Sprint2_RoboArena/BuffManager.py
+++ b/src/Sprint2_RoboArena/BuffManager.py
@@ -1,0 +1,69 @@
+import random
+import pygame
+
+class BuffManager:
+
+    def __init__(self):
+
+        self.font = pygame.font.SysFont(None, 36)
+        self.big_font = pygame.font.SysFont(None, 60)
+
+        self.available_buffs = [
+            "Mehr Leben",
+            "Mehr Geschwindigkeit",
+            "Mehr Schaden"
+        ]
+
+        self.current_choices = []
+        self.active = False
+
+    def generate_choices(self):
+
+        self.current_choices = random.sample(self.available_buffs, 2)
+        self.active = True
+
+    def apply_buff(self, index, robot, health):
+
+        buff = self.current_choices[index]
+
+        if buff == "Mehr Leben":
+            health.max_health += 20
+            health.current_health += 20
+
+        elif buff == "Mehr Geschwindigkeit":
+            pass
+             # TODO: ADD SPEED_LOGIC
+
+        elif buff == "Mehr Schaden":
+            pass
+            # TODO: ADD DAMAGE_LOGIC
+
+        self.active = False
+        self.current_choices = []
+
+    def draw(self, screen):
+
+        if not self.active:
+            return
+
+        title = self.big_font.render(
+            "LEVEL UP!",
+            True,
+            (255, 255, 255)
+        )
+
+        option1 = self.font.render(
+            f"1 - {self.current_choices[0]}",
+            True,
+            (255, 255, 255)
+        )
+
+        option2 = self.font.render(
+            f"2 - {self.current_choices[1]}",
+            True,
+            (255, 255, 255)
+        )
+        screen.blit(title, (350, 300))
+        screen.blit(option1, (350, 400))
+        screen.blit(option2, (350, 450))
+

--- a/src/Sprint2_RoboArena/Level.py
+++ b/src/Sprint2_RoboArena/Level.py
@@ -1,5 +1,4 @@
 import pygame
-from BuffManager import BuffManager
 
 
 class Level:

--- a/src/Sprint2_RoboArena/Level.py
+++ b/src/Sprint2_RoboArena/Level.py
@@ -1,9 +1,10 @@
 import pygame
+from BuffManager import BuffManager
 
 
 class Level:
 
-    def __init__(self, screen, x=10, y=75):
+    def __init__(self, screen):
 
         self.screen = screen
 
@@ -17,20 +18,20 @@ class Level:
 
         self.font = pygame.font.SysFont(None, 36)
 
-        self.x = x
-        self.y = y
+        self.x = screen.get_width() - 270
+        self.y = 10
 
 
-    def collect_orb(self):
+    def collect_orb(self, buff_manager):
 
         self.current_orbs += 1
 
         # wenn genug Orbs gesammelt wurden
         if self.current_orbs >= self.orbs_needed:
-            self.level_up()
+            self.level_up(buff_manager)
 
 
-    def level_up(self):
+    def level_up(self, buff_manager):
 
         self.current_level += 1
 
@@ -40,13 +41,46 @@ class Level:
         # Fortschritt zurücksetzen
         self.current_orbs = 0
 
+        #Buffmanger aufrufen
+
+        buff_manager.generate_choices()
+
     # Zeichnet die Anzeige
     def draw(self):
 
         text = self.font.render(
-            f"Level: {self.current_level}  Orbs: {self.current_orbs}/{self.orbs_needed}",
+            f"Level: {self.current_level} ",
             True,
             (255,255,255)
         )
 
         self.screen.blit(text, (self.x, self.y))
+
+        bar_x = self.x
+        bar_y = self.y + 35
+        bar_width = 250
+        bar_height = 20
+
+        # Hintergrund
+        pygame.draw.rect(
+            self.screen,
+            (60, 60, 60),
+            (bar_x, bar_y, bar_width, bar_height)
+        )
+
+        # Füllstand
+        fill_width = int(bar_width * (self.current_orbs / self.orbs_needed))
+
+        pygame.draw.rect(
+            self.screen,
+            (0, 200, 255),
+            (bar_x, bar_y, fill_width, bar_height)
+        )
+
+        # Rahmen
+        pygame.draw.rect(
+            self.screen,
+            (255, 255, 255),
+            (bar_x, bar_y, bar_width, bar_height),
+            1
+        )

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -7,6 +7,7 @@ from HealthSystem_Player import HealthSystem_Player
 from StaminaSystem_Player import StaminaSystem_Player
 from EnemyManager import EnemyManager
 from Level import Level
+from BuffManager import BuffManager
 TEST_MODE = False    # TESTMODE: wenn true, dann ist testmodus an
 
 SCREEN_WIDTH = 1000
@@ -46,12 +47,13 @@ def update():
     # TODO: REFACTOR IT
     for orb in orb_list[:]:
         if robot.aabb.check_collision(orb.aabb):
-            level.collect_orb()
+            level.collect_orb(buff_manager)
             orb.randomize_position()
 
 
 # Zeichne alles
 def draw():
+    screen.fill((0, 0, 0))
     arena.draw(robot)
     robot.draw()
     for orb in orb_list:
@@ -63,6 +65,7 @@ def draw():
     stamina.draw()
     level.draw()
 
+    buff_manager.draw(screen)
 
 # Testmodus
 # "visualisiert ausgewählte hintergrundberechnungen und andere testbedingte werte"
@@ -92,6 +95,7 @@ health = HealthSystem_Player(screen, max_health=100, bar_x=10, bar_y=10, bar_wid
 stamina = StaminaSystem_Player(screen, max_stamina=100, bar_x=10, bar_y=40, bar_width=400, bar_height=25)
 # Level-system
 level = Level(screen)
+buff_manager = BuffManager()
 
 # Create arena object
 arena = Arena(screen)
@@ -121,7 +125,17 @@ while True:
             pygame.quit()
             exit()
 
-    update()  # update all objects
+        if event.type == pygame.KEYDOWN:
+
+            if buff_manager.active:
+
+                if event.key == pygame.K_1:
+                    buff_manager.apply_buff(0, robot, health)
+
+                elif event.key == pygame.K_2:
+                    buff_manager.apply_buff(1, robot, health)
+    if not buff_manager.active:
+        update()  # update all objects
     draw()    # draw all objects
 
     pygame.display.flip() #update screen


### PR DESCRIPTION
Issue #42 wurde bearbeitet.

Der Bug wurde durch screen.fill((0,0,0)) behoben.

Zusätzlich wurde die neue Klasse BuffManager erstellt. In dieser erfolgen die Draws des Level-Up-Menüs genauso wie die Verwaltung und Anwendung der Buffs.

Im Level-System wird nun der BuffManager aufgerufen. Außerdem wurde die bisherige ExpAnzeige zu einer Leiste umgebaut und  nach oben rechts verschoben.

In der Main-Loop wird die Game-Loop bei einem Level-Up unterbrochen. Dem Spieler werden zwei zufällige Buffs zur Auswahl angezeigt, von denen er mit den Tasten 1 oder 2 einen auswählen kann. Dannach wird der gewählte Buff angewendet und die Game-Loop fortgesetzt.

Anknüpfend wurde hier noch das Issue #50 hinzugefügt, da sonnst der Umfang des Prs gesprengt worden wäre.