### PR TITLE
Gegner spawnen periodisch

### DIFF
--- a/src/Sprint2_RoboArena/EnemyManager.py
+++ b/src/Sprint2_RoboArena/EnemyManager.py
@@ -1,4 +1,5 @@
 from Enemy import Enemy
+from Orb import Orb
 
 
 # Updated Liste von Gegnern, die am Leben sind
@@ -11,14 +12,15 @@ class EnemyManager:
     def add_enemy(self, x, y):
         new_enemy = Enemy(self.arena, x, y)
         self.enemies.append(new_enemy)
+        print("Gegner gespawned")
 
     # Updated Liste an lebenden Gegnern
-    # Sobald ein Gegner hinzugefügt/entfernt wird, wird eine neue Liste mit/ohne den Gegner erstellt
-    def update(self, robot):
-        self.enemies = [
-            e for e in self.enemies
-            if not (hasattr(e, 'health_system') and e.health_system.is_dead())
-        ]
+    def update(self, robot, orb_list, arena):
+        for enemy in self.enemies[:]:
+            if hasattr(enemy, 'health_system') and enemy.health_system.is_dead(): # Wenn Gegner tot ist
+                new_orb = Orb(arena, enemy.x, enemy.y)
+                orb_list.append(new_orb) # Erstelle neuen Orb und füge ihn der Liste hinzu
+                self.enemies.remove(enemy) # Entferne Gegner aus der Liste
 
         MAX_CALCS_PER_FRAME =  2 # Maximale Anzahl an A* Berechnungen pro Frame
         calcs_done_this_frame = 0
@@ -32,10 +34,3 @@ class EnemyManager:
 
             if did_calculate:
                 calcs_done_this_frame += 1
-
-    def get_dead_positions(self):
-        dead_positions = [
-            (e.x, e.y) for e in self.enemies
-            if hasattr(e, 'health_system') and e.health_system.is_dead()
-        ]
-        return dead_positions

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -8,6 +8,7 @@ from StaminaSystem_Player import StaminaSystem_Player
 from EnemyManager import EnemyManager
 from Level import Level
 from BuffManager import BuffManager
+
 TEST_MODE = False    # TESTMODE: wenn true, dann ist testmodus an
 
 SCREEN_WIDTH = 1000
@@ -27,13 +28,8 @@ def update():
     arena.update_lightning_tiles(robot, health)
     arena.update_tornado(robot, health)
 
-    # Fügt Orb zur Orbliste hinzu, wenn Gegner stirbt
-    dead_positions = enemy_manager.get_dead_positions()
-    for x,y in dead_positions:
-        new_orb = Orb(arena,x,y)
-        orb_list.append(new_orb)
     # Updated Liste an Gegner (Gegner die am Leben sind, Path von Gegner zu Spieler)
-    enemy_manager.update(robot)
+    enemy_manager.update(robot, orb_list, arena)
     for enemy in enemy_manager.enemies:
         enemy.check_damage_player(robot, health)
 
@@ -46,7 +42,7 @@ def update():
     for orb in orb_list[:]:
         if robot.aabb.check_collision(orb.aabb):
             level.collect_orb(buff_manager)
-            orb.randomize_position()
+            orb_list.remove(orb)
 
 
 # Zeichne alles
@@ -103,8 +99,13 @@ arena.camera.y = robot.y # lässt kamera auf roboter spwanen
 
 orb_list = [Orb(arena,0,0), Orb(arena,0,0)]
 enemy_manager = EnemyManager(arena)
-for _ in range(2):
-    enemy_manager.add_enemy(0, 0)
+# Definiere Event, welches alle x Sekunden Gegner spawnen soll
+SPAWN_ENEMY_EVENT = pygame.USEREVENT + 1
+pygame.time.set_timer(SPAWN_ENEMY_EVENT, 1000)
+def spawn_enemy():
+    for _ in range(2):
+        enemy_manager.add_enemy(0, 0)
+        enemy_manager.enemies[-1].randomize_position()
 
 # randomize orb/enemy positions
 for orb in orb_list:
@@ -132,6 +133,13 @@ while True:
 
                 elif event.key == pygame.K_2:
                     buff_manager.apply_buff(1, robot, health)
+
+        if event.type == SPAWN_ENEMY_EVENT:
+            if len(enemy_manager.enemies) >= 10:
+                pass
+            else:
+                spawn_enemy()
+
     if not buff_manager.active:
         update()  # update all objects
     draw()    # draw all objects


### PR DESCRIPTION
Resolves #55 

### Change 1:
Jede 1 Sekunde spawnen 2 Gegner außerhalb des Screens. Die maximale Gegnerzahl ist auf 10 begrenzt.

### Change 2:
Bugfix: Wenn Gegner gestorben sind, wurden nicht nur 1 Orb gespawned, sondern jeden Frame, so lange bis der Gegner erst durch update() aus der "Lebenden-Liste" gelöscht wurden.
