### PR TITLE
Feature/visual status effects

### DIFF
--- a/src/Sprint2_RoboArena/Roboter.py
+++ b/src/Sprint2_RoboArena/Roboter.py
@@ -3,6 +3,7 @@ import math
 from Collision import AABB
 
 
+
 class Robot:
     def __init__(self, arena, health, stamina, level, x, y):
         self.arena  = arena
@@ -110,7 +111,42 @@ class Robot:
         self.speed_current = self.speed_base
         self.undo_all_status_effects()
 
+    # draws the icons of the status effects
+    def draw_status_effects(self):
+        # if there are no status_effects skip everything
+        if(not self.status_effects):
+            return
 
+        # get some values to define the icon_panel size and position
+        panel_pos = [10, 80]
+        icons_per_row = 7
+        temp_effect = self.status_effects[0]
+        icon_width =  temp_effect.ICON_WIDTH
+        icon_height = temp_effect.ICON_HEIGHT
+        icon_space = 5    # space between icons
+
+        # Transparent container surface
+        icon_panel = pygame.Surface((icon_width * icons_per_row, icon_height), pygame.SRCALPHA)
+
+        # Draw icons onto the panel
+        index=0
+        for effect in self.status_effects:
+            # Position des Icons abhängig vom Index
+            icon_pos = (index*(icon_width+icon_space), 0)
+
+            # Zeichne Icon auf Icon_Panel
+            icon = effect.get_icon()
+            icon_panel.blit(icon, icon_pos)
+
+            # Zeichne die verbleibende Dauer über Effect_Icon
+            icon_overlay = effect.get_icon_overlay()
+            icon_panel.blit(icon_overlay, icon_pos)
+
+            # Verschiebe den Index
+            index += 1
+
+        # Zeichne auf den screen
+        self.screen.blit(icon_panel, panel_pos)
 
     # Zeichner den Roboter
     def draw(self):

--- a/src/Sprint2_RoboArena/Status_Effects.py
+++ b/src/Sprint2_RoboArena/Status_Effects.py
@@ -1,10 +1,20 @@
-
+import pygame
 
 SECOND = 60   # because 60FPS at the Moment
 
 
-# Allgemeine Klasse für Effekte 
+
+
+
+
+
+# -------------------------------------------------------- Allgemeine Klassen und Methoden ----------------- 
 class Effect:
+
+    ICON_WIDTH = 20
+    ICON_HEIGHT = 20
+    ICON_DURATION_COLOR = (0,0,0)  # (schwarz) Farbe des icon-overlays für duration
+
     def __init__(self):
         self.ttl_max = 0
         self.ttl_current = 0
@@ -17,6 +27,16 @@ class Effect:
     # sets the ttl to 0
     def undo(self):
         self.ttl_current = 0
+
+    # draws a corresponding Icon at the given location
+    def draw(self,x,y):
+        pass
+
+    def get_icon_overlay(self):
+        duration_fraction = 1 - (self.ttl_current / self.ttl_max)
+        width = duration_fraction * self.ICON_WIDTH
+        return make_icon_overlay(width, self.ICON_HEIGHT, self.ICON_DURATION_COLOR)
+        
 
 
 # Allgemeine Klasse für Effekt die periodisch ausgelöst werden
@@ -35,7 +55,30 @@ class Tick_Effect(Effect):
         pass
 
 
-# -----------------------------------------------------------------------------------
+# Zeichnet ein Surface mit einem gegebenen Text
+def make_icon(width, height, color, text):
+    # Create colored surface
+    surface = pygame.Surface((width, height))
+    surface.fill(color)  
+    # Create text surface
+    font = pygame.font.Font(None, 10)  
+    text = font.render(text, True, (0, 0, 0))  # black tex
+    # Center text on button
+    text_rect = text.get_rect(center=(width/2, height/2))
+    surface.blit(text, text_rect)
+
+    return surface
+
+# Zeichnet eine halbdurchsichtiges Rechteck, Größe abhängig von TTL-fraction
+def make_icon_overlay(width, height, color):
+    surface = pygame.Surface((width, height))
+    surface.set_alpha(128)  # 0 = unsichtbar, 255 = voll sichtbar
+    surface.fill(color) 
+
+    return surface
+
+
+# ------------------------------------------------------------------------------------------------------
 
 
 # 01 Speed Buff
@@ -81,6 +124,10 @@ class Speed_Buff(Effect):
         # Tick down Time-to-Live
         self.ttl_current -= 1
 
+    def get_icon(self):
+        color = (255,255,0)  # gelb
+        return make_icon(self.ICON_WIDTH, self.ICON_HEIGHT, color, "speed")
+
 
 # Health-Regernaration-Buff
 class Healthgen_Buff(Tick_Effect):
@@ -109,6 +156,10 @@ class Healthgen_Buff(Tick_Effect):
         # update TTL
         self.ttl_current -= 1
 
+    def get_icon(self):
+            color = (255, 192, 203)  # pink
+            return make_icon(self.ICON_WIDTH, self.ICON_HEIGHT, color, "heal")
+
 
 # Poison-Debuff
 class Poison_Debuff(Tick_Effect):
@@ -127,6 +178,10 @@ class Poison_Debuff(Tick_Effect):
         
         # update TTL
         self.ttl_current -= 1
+
+    def get_icon(self):
+        color = (128, 0, 128)  # lila
+        return make_icon(self.ICON_WIDTH, self.ICON_HEIGHT, color, "poison")
 
 
 

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -73,6 +73,7 @@ def draw():
 # "visualisiert ausgewählte hintergrundberechnungen und andere testbedingte werte"
 def test_mode():
     if(TEST_MODE):
+        # Zeichnungen
         for orb in orb_list:
             orb.draw_aabb() 
         robot.draw_aabb()
@@ -81,6 +82,9 @@ def test_mode():
             enemy.draw_aabb()
             enemy.draw_line_enemy(robot)
         arena.draw_aabb()
+
+        # Konsolenausgaben
+        print(robot.status_effects)
 
 
 

--- a/src/Sprint2_RoboArena/main.py
+++ b/src/Sprint2_RoboArena/main.py
@@ -55,6 +55,7 @@ def draw():
     screen.fill((0, 0, 0))
     arena.draw(robot)
     robot.draw()
+    robot.draw_status_effects()
     for orb in orb_list:
         orb.draw()
     for enemy in enemy_manager.enemies:


### PR DESCRIPTION
Bisher war nicht sichther welche temporären Buffs/Debuffs man gerade hat und wie lange sie noch andauern.

Dies sieht der Spieler nun unter seiner Stamina-Leiste.
Dort werden Icons angezeigt die Dauer und Art des Buffs/Debuffs anzeigen.

- Zeichnen der Status-Effekte wurde in der Roboter-Klasse eingeführt und in main zur draw Methode hinzugefügt
- Eine globale Methode zum zeichnen von Icon-Platzhaltern sowie dem Duration-Overlay wurde eingeführt
- Testmodus wurde mit einem print erweitert



Das ganze scheint etwas ins überladene abzudriften, demnach sollte sich überlegt werden ein größeres refactoring durchzuführen, z.B. ein neues File explizit für das User-Interface zu erstellen oder ähnliches.

Wurde lokal getestet und schient zu funktionieren wie es sollte.
Resolves #63 